### PR TITLE
Avoid status.list() for speed and compatibility

### DIFF
--- a/lualibs.dtx
+++ b/lualibs.dtx
@@ -505,9 +505,8 @@ do
   lualibs.error, lualibs.warn, lualibs.info = error, warn, info
 end
 
-local info = status.list()
-if info.kpse_used == 0 then
- kpse.set_program_name("luatex")
+if status.kpse_used == 0 then
+  kpse.set_program_name("luatex")
 end
 
 find_file = kpsefind_file


### PR DESCRIPTION
`status.list()` creates an entire table, this can be avoiding by querying the actually needed entry directly. This is slightly faster, easier to read and avoids a segfault under luametatex.