### PR TITLE
Fix tocardinal() functions.

### DIFF
--- a/lualibs-util-sac.lua
+++ b/lualibs-util-sac.lua
@@ -551,14 +551,14 @@ if bit32 and not streams.tocardinal1 then
     local char    = string.char
 
              streams.tocardinal1           = char
-    function streams.tocardinal2(n)   return char(extract( 8,8),extract( 0,8)) end
-    function streams.tocardinal3(n)   return char(extract(16,8),extract( 8,8),extract(0,8)) end
-    function streams.tocardinal4(n)   return char(extract(24,8),extract(16,8),extract(8,8),extract(0,8)) end
+    function streams.tocardinal2(n)   return char(extract(n, 8,8),extract(n, 0,8)) end
+    function streams.tocardinal3(n)   return char(extract(n,16,8),extract(n, 8,8),extract(n,0,8)) end
+    function streams.tocardinal4(n)   return char(extract(n,24,8),extract(n,16,8),extract(n,8,8),extract(n,0,8)) end
 
              streams.tocardinal1le         = char
-    function streams.tocardinal2le(n) return char(extract(0,8),extract(8,8)) end
-    function streams.tocardinal3le(n) return char(extract(0,8),extract(8,8),extract(16,8)) end
-    function streams.tocardinal4le(n) return char(extract(0,8),extract(8,8),extract(16,8),extract(24,8)) end
+    function streams.tocardinal2le(n) return char(extract(n,0,8),extract(n,8,8)) end
+    function streams.tocardinal3le(n) return char(extract(n,0,8),extract(n,8,8),extract(n,16,8)) end
+    function streams.tocardinal4le(n) return char(extract(n,0,8),extract(n,8,8),extract(n,16,8),extract(n,24,8)) end
 
 end
 


### PR DESCRIPTION
As already described in #7 lualibs 2.75 creates gzip files that gunzip cannot read.

The reason for this - as explained in the issue - is that the tocardinal() functions call extract() without passing their parameter.