### PR TITLE
fix a doc typo, \email -> \url

### DIFF
--- a/lualibs.dtx
+++ b/lualibs.dtx
@@ -211,7 +211,7 @@ and lualibs-extended.lua.
 % \date{2023/07/13 v2.76}
 % \author{Élie Roux      · \email{elie.roux@telecom-bretagne.eu}\\
 %         Philipp Gesang · \email{phg@phi-gamma.net}\\
-%         The \LaTeX{} Project · \email{https://github.com/latex3/lualibs/}\\
+%         The \LaTeX{} Project · \url{https://github.com/latex3/lualibs/}\\
 %         }
 %
 % \maketitle


### PR DESCRIPTION
Introduced in commit da63abf (uploaded version 2.69, docu corrections, 2019-11-06), when ownership was transferred to the LaTeX Project Team.